### PR TITLE
Use native `position: sticky` when available

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,9 @@
+extends: 'eslint:recommended'
+
+parserOptions:
+  sourceType: "module"
+  ecmaVersion: 6
+
 ecmaFeatures:
   modules: true
 
@@ -23,5 +29,4 @@ globals:
 env:
   es6: true
   browser: true
-
-extends: 'eslint:recommended'
+  node: true

--- a/example/app.vue
+++ b/example/app.vue
@@ -10,24 +10,18 @@ export default {
   directives: {
     'sticky': VueSticky,
   },
-  events: {
-    STICKY_STATE({ isSticky, el }) {
-      console.log(isSticky, el);
-    },
-  },
 };
 </script>
 
 <template>
-  <div v-sticky :z-index="100">to be sticky</div>
+  <p v-for="item in ['before', 'sticky', 'enabled']">{{item}}</p>
+  <nav v-sticky :z-index="100" :sticky-top="50"><div>to be sticky</div></nav>
   <p v-for="item in fillArray">{{item}}</p>
 </template>
 
 <style>
   body {
     margin: 0;
-    height: 10000px;
-    /*padding-top: 100px;*/
   }
   div {
     line-height: 200px;

--- a/example/example.html
+++ b/example/example.html
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>example</title>
-  <script src="//fe-static.ele.me/github/amfe/lib-flexible/master/build/flexible.js"></script>
+  <title>Sticky example</title>
 </head>
 <body>
   <app></app>

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -1,27 +1,15 @@
 /*eslint-env node */
-const cssnext = require('postcss-cssnext');
-const postcssNested = require('postcss-nested');
-const postcssFlexFallback = require('postcss-flex-fallback');
-const postcssPx2rem = require('postcss-px2rem');
 
 module.exports = {
   module: {
     loaders: [
       { test: /\.vue$/, loader: 'vue' },
       { test: /\.js$/, loader: 'babel' },
-      { test: /\.svg$/, loader: 'url?limit=10000'},
     ],
   },
   vue: {
     loaders: {
       js: 'babel!eslint',
     },
-    autoprefixer: false,
-    postcss: [
-      postcssNested(),
-      cssnext({ browsers: ['last 2 versions', 'Android >= 2.1', 'iOS >= 7.0'] }),
-      postcssFlexFallback(),
-      postcssPx2rem({remUnit: 73}),
-    ],
   },
 };


### PR DESCRIPTION
Improvements of VueSticky:
1. Use native `position: sticky` when available
2. ~~Use rAF instead of setTimeout to improve user experience & maybe performance~~

Breaking changes:
1. For performance reasons, we don't fire events when changing sticky state, since events are slow and not very useful here. And native css sticky doesn't fire events at all.
2. For simplicity, we require a wrapper element for sticky element. VueSticky will set its height dynamically.

Minor:
1. Migrate `.eslintrc` to eslint 2
2. Remove useless webpack configurations
3. Example cleanups

Reference: https://fe.ele.me/position-sticky-zai-yi-dong-duan-de-ying-yong-yu-shi-jian/
