### PR TITLE
Vue-Sticky working on Vue 1.0+ and 2.0+

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,10 @@ const VueSticky = {
     'z-index',
   ],
   bind(element, bindings) {
-    const params = (this && this.params) ?
-      this.params :
-      null,
+    const params = (this && this.params) ? this.params : null,
       stickyTop = ((params && this.params.stickyTop) ?
-      this.params.stickyTop :
-      bindings.value.stickyTop) || 0,
+        this.params.stickyTop :
+        bindings.value.stickyTop) || 0,
       zIndex = ((params && this.params.stickyTop) ?
         this.params.stickyTop :
         bindings.value.zIndex) || 1000;

--- a/src/index.js
+++ b/src/index.js
@@ -1,62 +1,60 @@
 const VueSticky = {
-  params: [
-    // sticky 元素固定相对屏幕高度
-    'sticky-top',
-    // fixed 时 元素的z-index
-    'z-index',
-  ],
-  bind() {
-    const stickyTop = this.params.stickyTop || 0;
-    const zIndex = this.params.zIndex || 1000;
-    const element = this.el;
+  bind(element, bindings) {
+    const stickyTop = bindings.value.stickyTop || 0,
+      zIndex = bindings.value.zIndex || 1000,
+      transition = bindings.value.transition || 'none',
+      elementStyle = element.style;
 
-    element.style.position = '-webkit-sticky';
-    element.style.position = 'sticky';
+    elementStyle.position = '-webkit-sticky';
+    elementStyle.position = 'sticky';
+    elementStyle.transition = transition;
 
-    if (~element.style.position.indexOf('sticky')) {
+    /* eslint-disable no-bitwise */
+    if (~elementStyle.position.indexOf('sticky')) {
+      /* eslint-enable no-bitwise */
       // 浏览器支持原生 sticky 效果（Currently Safari, Firefox and Chrome Canary）
-      element.style.top = `${stickyTop}px`;
-      element.style.zIndex = zIndex;
+      elementStyle.top = `${stickyTop}px`;
+      elementStyle.zIndex = zIndex;
       return;
     }
+    const elementChildStyle = element.firstElementChild.style;
+    elementChildStyle.left = 0;
+    elementChildStyle.right = 0;
+    elementChildStyle.top = `${stickyTop}px`;
+    elementChildStyle.zIndex = zIndex;
 
-    const elementChild = element.firstElementChild;
-    elementChild.style.left = 0;
-    elementChild.style.right = 0;
-    elementChild.style.top = `${stickyTop}px`;
-    elementChild.style.zIndex = zIndex;
-
-    let active = false;
+    let vueStickyActiveVariable = false;
 
     const check = () => {
       const offsetTop = element.getBoundingClientRect().top;
       if (offsetTop <= stickyTop) {
-        if (active) return;
-        if (!element.style.height) {
-          element.style.height = element.clientHeight + 'px';
+        if (vueStickyActiveVariable) return;
+        if (!elementStyle.height) {
+          elementStyle.height = `${element.clientHeight}px`;
         }
         elementChild.style.position = 'fixed';
-        active = true;
+        vueStickyActiveVariable = true;
       } else {
-        if (!active) return;
+        if (!vueStickyActiveVariable) return;
         elementChild.style.position = '';
-        active = false;
+        vueStickyActiveVariable = false;
       }
     };
 
-    var timer;
-    this.__listenAction = () => {
-      if (timer) return;
-      timer = setInterval(check, 30);
-    }
-
-    window.addEventListener('scroll', this.__listenAction);
+    let vueStickyTimerVariable;
+    const vueStickyListenAction = () => {
+      if (vueStickyTimerVariable) return;
+      vueStickyTimerVariable = setInterval(check, 30);
+    };
+    /* eslint-disable no-undef */
+    window.addEventListener('scroll', vueStickyListenAction);
   },
   unbind() {
-    if (this.__listenAction) {
-      window.removeEventListener('scroll', this.__listenAction);
+    if (vueStickyListenAction) {
+      window.removeEventListener('scroll', vueStickyListenAction);
     }
   },
+  /* eslint-enable no-undef */
 };
 
 export default VueSticky;

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,6 @@
 const VueSticky = {
   params: [
-    // sticky 元素固定相对屏幕高度
     'sticky-top',
-    // fixed 时 元素的z-index
     'z-index',
   ],
   bind(element, bindings) {
@@ -54,10 +52,8 @@ const VueSticky = {
       }
     };
 
-    let vueStickyTimerVariable;
     const vueStickyListenAction = () => {
-      if (vueStickyTimerVariable) return;
-      vueStickyTimerVariable = setInterval(check, 200);
+      setTimeout(check, 300);
     };
     /* eslint-disable no-undef */
     window.addEventListener('scroll', vueStickyListenAction);

--- a/src/index.js
+++ b/src/index.js
@@ -12,17 +12,18 @@ const VueSticky = {
         bindings.value.stickyTop) || 0,
       zIndex = ((params && this.params.stickyTop) ?
         this.params.stickyTop :
-        bindings.value.zIndex) || 1000;
+        bindings.value.zIndex) || 1000,
+      elementStyle = (this && this.el ? this.el : element).style;
 
-    element.style.position = '-webkit-sticky';
-    element.style.position = 'sticky';
+    elementStyle.position = '-webkit-sticky';
+    elementStyle.position = 'sticky';
 
     /* eslint-disable no-bitwise */
-    if (~element.style.position.indexOf('sticky')) {
+    if (~elementStyle.position.indexOf('sticky')) {
       /* eslint-enable no-bitwise */
       // 浏览器支持原生 sticky 效果（Currently Safari, Firefox and Chrome Canary）
-      element.style.top = `${stickyTop}px`;
-      element.style.zIndex = zIndex;
+      elementStyle.top = `${stickyTop}px`;
+      elementStyle.zIndex = zIndex;
       return;
     }
     const elementChildStyle = element.firstElementChild.style;
@@ -41,8 +42,8 @@ const VueSticky = {
       const offsetTop = element.getBoundingClientRect().top;
       if (offsetTop <= stickyTop) {
         if (vueStickyActiveVariable) return;
-        if (!element.style.height) {
-          element.style.height = `${element.clientHeight}px`;
+        if (!elementStyle.height) {
+          elementStyle.height = `${element.clientHeight}px`;
         }
         elementChildStyle.position = 'fixed';
         vueStickyActiveVariable = true;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,10 @@
 const VueSticky = {
+  params: [
+    // sticky 元素固定相对屏幕高度
+    'sticky-top',
+    // fixed 时 元素的z-index
+    'z-index',
+  ],
   bind(element, bindings) {
     const stickyTop = bindings.value.stickyTop || 0,
       zIndex = bindings.value.zIndex || 1000,

--- a/src/index.js
+++ b/src/index.js
@@ -6,21 +6,25 @@ const VueSticky = {
     'z-index',
   ],
   bind(element, bindings) {
-    const stickyTop = bindings.value.stickyTop || 0,
-      zIndex = bindings.value.zIndex || 1000,
-      transition = bindings.value.transition || 'none',
-      elementStyle = element.style;
+    const params = (this && this.params) ?
+      this.params :
+      null,
+      stickyTop = ((params && this.params.stickyTop) ?
+      this.params.stickyTop :
+      bindings.value.stickyTop) || 0,
+      zIndex = ((params && this.params.stickyTop) ?
+        this.params.stickyTop :
+        bindings.value.zIndex) || 1000;
 
-    elementStyle.position = '-webkit-sticky';
-    elementStyle.position = 'sticky';
-    elementStyle.transition = transition;
+    element.style.position = '-webkit-sticky';
+    element.style.position = 'sticky';
 
     /* eslint-disable no-bitwise */
-    if (~elementStyle.position.indexOf('sticky')) {
+    if (~element.style.position.indexOf('sticky')) {
       /* eslint-enable no-bitwise */
       // 浏览器支持原生 sticky 效果（Currently Safari, Firefox and Chrome Canary）
-      elementStyle.top = `${stickyTop}px`;
-      elementStyle.zIndex = zIndex;
+      element.style.top = `${stickyTop}px`;
+      element.style.zIndex = zIndex;
       return;
     }
     const elementChildStyle = element.firstElementChild.style;
@@ -29,20 +33,24 @@ const VueSticky = {
     elementChildStyle.top = `${stickyTop}px`;
     elementChildStyle.zIndex = zIndex;
 
-    let vueStickyActiveVariable = false;
+    /* eslint-disable vars-on-top */
+    /* eslint-disable no-var */
+    var vueStickyActiveVariable = false;
+    /* eslint-enable vars-on-top */
+    /* eslint-enable no-var */
 
     const check = () => {
       const offsetTop = element.getBoundingClientRect().top;
       if (offsetTop <= stickyTop) {
         if (vueStickyActiveVariable) return;
-        if (!elementStyle.height) {
-          elementStyle.height = `${element.clientHeight}px`;
+        if (!element.style.height) {
+          element.style.height = `${element.clientHeight}px`;
         }
-        elementChild.style.position = 'fixed';
+        elementChildStyle.position = 'fixed';
         vueStickyActiveVariable = true;
       } else {
         if (!vueStickyActiveVariable) return;
-        elementChild.style.position = '';
+        elementChildStyle.position = '';
         vueStickyActiveVariable = false;
       }
     };
@@ -50,7 +58,7 @@ const VueSticky = {
     let vueStickyTimerVariable;
     const vueStickyListenAction = () => {
       if (vueStickyTimerVariable) return;
-      vueStickyTimerVariable = setInterval(check, 30);
+      vueStickyTimerVariable = setInterval(check, 200);
     };
     /* eslint-disable no-undef */
     window.addEventListener('scroll', vueStickyListenAction);


### PR DESCRIPTION
I was having trouble using this directive then I checked the `package.json` on vue-sticky repo and saw that it used the Vue 1.0 version. So here is a fix to work on both versions.

### Instalation
```bash
$ yarn add -D vue-sticky
```

**OR**
```bash
$ npm -i --save-dev vue-sticky
```

Then, add it to your project:
```javascript
import Vue from 'vue';
import VueStricky from 'vue-sticky';

Vue.directive('sticky', VueStricky);
```

### How to use it
To add this directive on Vue **1.0+**:
```html
<ELEMENT v-sticky
  :z-index="NUMBER"
  :sticky-top="NUMBER">

  <div> <!-- sticky wrapper, IMPORTANT -->
    CONTENT
  </div>
</ELEMENT>
```

To add this directive on Vue **2.0+**:
```html
<ELEMENT v-sticky="{ stickyTop: NUMBER, zIndex: NUMBER }">
  <div> <!-- sticky wrapper, IMPORTANT -->
    CONTENT
  </div>
</ELEMENT>
```

> the `NUMBER` on both examples above should be replaced by a number of your choice.

### Improvements

* I created some new variables so the directive stops doing memory search on the elements attributes;
* I changed the `bind` method so it could use either Vue 1.0+ or 2.0+;
* I added some disable eslint rules so it could run anywhere with no problem;
* I added a string interpolation on line 46
* [fixed the **Request of improvements**] After some tests I saw that this directive was creating an infinite event loop and not relying on the event itself to do its magic. I fixed it with the code below (this is the old `this.__listenAction` method). Instead of a `setInterval` I used the `setTimeout` function. It will hold back the `check` method and apply the element changes only a few milliseconds after the scroll event is done. This makes sure the `check` methods runs only when the user scroll the page.

```javascript
const vueStickyListenAction = () => {
      setTimeout(check, 300);
    };
```


### Issues

* I could not run the project out of the box, so I grabbed the code, move it to a new project and enhanced it;
* Please, make a working example;
* There where two missing packages: `vue` and `chokidar` (I can't really tell the reason why they were missing);


### Request of improvements

* ~~use a better strategy to start/stop the event only when its needed. The current code creates an event loop and keeps checking the scroll, even if the user is not scrolling.~~